### PR TITLE
feat(backend): switch from bcrypt to argon2, use rustls, add dockerfile

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+[target.x86_64-unknown-linux-gnu]
+linker = "/usr/bin/clang"
+rustflags = ["-C", "link-arg=--ld-path=/usr/bin/mold"]
+
+[target.x86_64-unknown-linux-musl]
+linker = "/usr/bin/clang"
+rustflags = ["-C", "link-arg=--ld-path=/usr/bin/mold"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,16 +435,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,21 +681,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1013,19 +988,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,24 +1234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,51 +1324,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "openssl"
-version = "0.10.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "os_str_bytes"
@@ -1566,12 +1465,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polyval"
@@ -1794,12 +1687,10 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1809,7 +1700,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -2006,15 +1896,6 @@ name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
-
-[[package]]
-name = "schannel"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
-dependencies = [
- "windows-sys 0.42.0",
-]
 
 [[package]]
 name = "scoped-tls"
@@ -2232,29 +2113,6 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
-name = "security-framework"
-version = "2.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "serde"
@@ -2676,16 +2534,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2917,12 +2765,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c2fcf79ad1932ac6269a738109997a83c227c09b75842ae564dc8ede6a861c"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "password-hash",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,8 +158,8 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 name = "backend"
 version = "0.1.0"
 dependencies = [
+ "argon2",
  "base64 0.21.0",
- "bcrypt",
  "entity",
  "migration",
  "oauth2",
@@ -193,17 +204,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
-name = "bcrypt"
-version = "0.14.0"
+name = "base64ct"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df288bec72232f78c1ec5fe4e8f1d108aa0265476e93097593c803c8c02062a"
-dependencies = [
- "base64 0.21.0",
- "blowfish",
- "getrandom",
- "subtle",
- "zeroize",
-]
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bigdecimal"
@@ -229,22 +233,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blowfish"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
-dependencies = [
- "byteorder",
- "cipher",
 ]
 
 [[package]]
@@ -1504,6 +1507,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -3172,9 +3186,3 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
-
-[[package]]
-name = "zeroize"
-version = "1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -15,8 +15,8 @@ time = "0.3.20"
 thiserror = "1.0.39"
 rand = "0.8.5"
 base64 = "0.21.0"
-oauth2 = "4.3.0"
-reqwest = { version = "0.11.14", features = ["json"] }
+oauth2 = { version = "4.3.0", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11.14", default-features = false, features = ["json", "rustls-tls"] }
 
 [dependencies.sea-orm]
 version = "0.11.0"

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 rocket = { version = "0.5.0-rc.2", features = ["serde_json", "json"] }
-bcrypt = "0.14.0"
+argon2 = "0.5.0"
 sea-orm-rocket = "0.5.2"
 entity = { path = "../entity" }
 migration = { path = "../migration" }

--- a/crates/backend/Dockerfile
+++ b/crates/backend/Dockerfile
@@ -1,0 +1,22 @@
+FROM rust:alpine as builder
+RUN apk add --no-cache musl-dev upx clang mold
+
+ARG project=backend
+
+WORKDIR /build
+COPY . .
+RUN RUSTFLAGS="-C linker=clang -C link-arg=-fuse-ld=/usr/bin/mold" cargo build --release -p "$project" && \
+    upx --best --lzma ./target/release/"$project"
+
+FROM alpine
+
+WORKDIR /app
+
+RUN addgroup -S app && adduser -S app -G app
+
+ARG project=backend
+COPY --from=builder /build/target/release/"$project" /app/app
+RUN chown app:app /app -R
+USER app:app
+
+ENTRYPOINT ["/app/app"]

--- a/oauth-job.nomad
+++ b/oauth-job.nomad
@@ -1,0 +1,91 @@
+
+job "oauth-nomad" {
+
+  group "database" {
+    count = 1
+
+    network {
+      mode = "bridge"
+      port "db" {
+        to = 5432
+      }
+    }
+
+    service {
+      name = "oauth-postgres"
+      port = "db"
+
+      connect {
+        sidecar_service {}
+      }
+    }
+
+    task "postgres" {
+      driver = "docker"
+
+      config {
+        image = "postgres:latest"
+      }
+
+      resources {
+        cpu = 300
+        memory = 1536
+      }
+
+      env {
+        POSTGRES_PASSWORD = "mysecretpassword"
+      }
+    }
+
+  }
+
+  group "backend" {
+    network {
+      mode = "bridge"
+      port "http" {
+        to = 80
+      }
+    }
+
+    service {
+      name = "oauth-backend"
+      port = "http"
+
+      connect {
+        sidecar_service {
+          proxy {
+            upstreams {
+              destination_name = "oauth-postgres"
+              local_bind_port = 5432
+            }
+          }
+        }
+      }
+    }
+
+    task "backend" {
+      driver = "docker"
+
+      config {
+        image = "ghcr.io/marekvospel/oauth2-backend"
+      }
+
+      resources {
+        cpu = 300
+        memory = 1536
+      }
+
+      env {
+        ROCKET_DATABASES = '{ sea_orm = { url = "postgres://postgres:mysecretpassword@localhost:5432" } }'
+        ROCKET_ADDRESS = '0.0.0.0'
+        ROCKET_PORT = '80'
+      }
+
+      lifecycle {
+        hook = "prestart"
+        sidecar = true
+      }
+    }
+  }
+
+}

--- a/oauth-job.nomad
+++ b/oauth-job.nomad
@@ -76,9 +76,9 @@ job "oauth-nomad" {
       }
 
       env {
-        ROCKET_DATABASES = '{ sea_orm = { url = "postgres://postgres:mysecretpassword@localhost:5432" } }'
-        ROCKET_ADDRESS = '0.0.0.0'
-        ROCKET_PORT = '80'
+        ROCKET_DATABASES = "{ sea_orm = { url = \"postgres://postgres:mysecretpassword@localhost:5432\" } }"
+        ROCKET_ADDRESS = "0.0.0.0"
+        ROCKET_PORT = "80"
       }
 
       lifecycle {

--- a/oauth-job.nomad
+++ b/oauth-job.nomad
@@ -1,19 +1,20 @@
 
-job "oauth-nomad" {
+job "oauth" {
 
-  group "database" {
+  group "oauth-database" {
     count = 1
 
     network {
       mode = "bridge"
-      port "db" {
-        to = 5432
+
+      port "postgres" {
+        static = "5432"
       }
     }
 
     service {
       name = "oauth-postgres"
-      port = "db"
+      port = "5432"
 
       connect {
         sidecar_service {}
@@ -39,17 +40,19 @@ job "oauth-nomad" {
 
   }
 
-  group "backend" {
+  group "oauth-api" {
+
     network {
       mode = "bridge"
-      port "http" {
-        to = 80
+
+      port "api" {
+        static = 80
       }
     }
 
     service {
-      name = "oauth-backend"
-      port = "http"
+      name = "oauth-api"
+      port = "80"
 
       connect {
         sidecar_service {
@@ -63,7 +66,7 @@ job "oauth-nomad" {
       }
     }
 
-    task "backend" {
+    task "oauth-api" {
       driver = "docker"
 
       config {
@@ -76,16 +79,12 @@ job "oauth-nomad" {
       }
 
       env {
-        ROCKET_DATABASES = "{ sea_orm = { url = \"postgres://postgres:mysecretpassword@localhost:5432\" } }"
+        ROCKET_DATABASES = "{ sea_orm = { url = \"postgres://postgres:mysecretpassword@127.0.0.1:5432\" } }"
         ROCKET_ADDRESS = "0.0.0.0"
         ROCKET_PORT = "80"
-      }
-
-      lifecycle {
-        hook = "prestart"
-        sidecar = true
       }
     }
   }
 
 }
+


### PR DESCRIPTION
This PR switches from bcrypt to a stronger hashing algorythm (argon2), this PR also creates the foundation to deploy the app to my nomad cluster, as I've added a Dockerfile and pushed an initial release to ghcr. While setting up the Dockerfile, I also updated all rust dependencies to use rustls whereever possible, so we don't have to deal with openssl.

- chore: switch to argon2
- chore: add dockerfile, nomad job file
- chore: add rocket env vars
- chore: update nomad jobspec
